### PR TITLE
Fix xml errors in XMLTemplateProvider

### DIFF
--- a/src/lib/PnP.Framework/Provisioning/Providers/Xml/XMLTemplateProvider.cs
+++ b/src/lib/PnP.Framework/Provisioning/Providers/Xml/XMLTemplateProvider.cs
@@ -325,6 +325,10 @@ namespace PnP.Framework.Provisioning.Providers.Xml
                 throw new ArgumentNullException(nameof(stream));
             }
             var res = stream;
+            
+            //rewind the stream so prevent accidental 'Root element is missing.'
+            stream.Seek(0, SeekOrigin.Begin);
+            
             XDocument xml = XDocument.Load(stream);
 
             //find XInclude elements by XName


### PR DESCRIPTION
Fixing the 'Root element not found.' error in case the incoming stream was not rewind to 0. For example if coming directly from Azure function blobClient.